### PR TITLE
Built Majority of "Forgot my Password"

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,5 @@
 from flask import Flask
 from flask_session import Session
-from flask_mail import Mail
 
 # Initializing app
 app = Flask(__name__)
@@ -10,7 +9,8 @@ app.config["SESSION_PERMANENT"] = False
 app.config["SESSION_TYPE"] = "filesystem"
 Session(app)
 
-# Setup flask mail stuff (for forgot_pwd only, not general emails)
-mail = Mail(app)
+# App is in testing mode, no emails acutally sent
+# TODO - turn me off once we're ready to deploy
+app.config["TESTING"] = True
 
 from app import routes

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,17 +1,16 @@
 from flask import Flask
 from flask_session import Session
-#from flask-login import LoginManager
+from flask_mail import Mail
 
 # Initializing app
 app = Flask(__name__)
 
 # Configure session to use filesystem (instead of signed cookies)
-#app.config["SESSION_FILE_DIR"] = mkdtemp()
 app.config["SESSION_PERMANENT"] = False
 app.config["SESSION_TYPE"] = "filesystem"
 Session(app)
 
-# Initialize login
-# login = LoginManager(app)
+# Setup flask mail stuff (for forgot_pwd only, not general emails)
+mail = Mail(app)
 
 from app import routes

--- a/app/routes.py
+++ b/app/routes.py
@@ -560,6 +560,12 @@ def RegisterStaff():
         
         return redirect("/")
 
-@app.route('/forgot_pwd')
+@app.route('/forgot_pwd', methods=['GET', 'POST'])
 def forgot_pwd():
-    return render_template('forgot_pwd.html')
+    if request.method == 'GET':
+        return render_template('forgot_pwd.html')
+    else:
+        recovery = request.form.get("recovery")
+
+        # send recovery email
+        return

--- a/app/routes.py
+++ b/app/routes.py
@@ -2,6 +2,7 @@ from app import app
 
 from flask import Flask, render_template, request, session, redirect, url_for, flash
 from flask_bootstrap import Bootstrap
+from flask_mail import Message
 #from flask.ext.sqlalchemy import SQLAlchemy
 import sqlite3
 from datetime import datetime 
@@ -568,4 +569,6 @@ def forgot_pwd():
         recovery = request.form.get("recovery")
 
         # send recovery email
+        # NOTE - IMPORTANT!!! CREATE TESTING EMAIL, DO NOT USE YOUR OWN!!!
+        # user email should be protected but we need a dummy "noreply" email
         return

--- a/app/routes.py
+++ b/app/routes.py
@@ -2,7 +2,7 @@ from app import app
 
 from flask import Flask, render_template, request, session, redirect, url_for, flash
 from flask_bootstrap import Bootstrap
-from flask_mail import Message
+from flask_mail import Mail, Message
 #from flask.ext.sqlalchemy import SQLAlchemy
 import sqlite3
 from datetime import datetime 
@@ -12,6 +12,9 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from functools import wraps
 # Initializing bootstrap
 bootstrap = Bootstrap(app)
+
+# Setup flask mail stuff (for forgot_pwd only, not general emails)
+mail = Mail(app)
 
 """
 # Initializing mailchimp
@@ -571,4 +574,19 @@ def forgot_pwd():
         # send recovery email
         # NOTE - IMPORTANT!!! CREATE TESTING EMAIL, DO NOT USE YOUR OWN!!!
         # user email should be protected but we need a dummy "noreply" email
-        return
+        with mail.record_messages() as outbox:
+            # test to see that mail "sent"
+            msg = Message(subject = "Water Walkers Password Recovery",
+                          body = "This is a test.", 
+                          sender = "FIXME", 
+                          recipients = ["FIXME"])
+
+            mail.send(msg)
+
+            assert len(outbox) == 1
+            assert outbox[0].subject == "Water Walkers Password Recovery"
+            assert outbox[0].body == "This is a test."
+
+
+        # TODO - add confirmation that email has been sent
+        return render_template("confirmation.html")

--- a/app/routes.py
+++ b/app/routes.py
@@ -606,6 +606,9 @@ def reset_password(index):
         # connect to database
         conn = sqlite3.connect('database/database.db')
         db = conn.cursor()
-        
+
+        db.execute("UPDATE MAIN SET password=?", (new_password,))
+        conn.commit()
+
         return redirect('/login')
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -574,6 +574,7 @@ def forgot_pwd():
         # send recovery email
         # NOTE - IMPORTANT!!! CREATE TESTING EMAIL, DO NOT USE YOUR OWN!!!
         # user email should be protected but we need a dummy "noreply" email
+        # TODO - send user link to reset password with index as user_id
         with mail.record_messages() as outbox:
             # test to see that mail "sent"
             msg = Message(subject = "Water Walkers Password Recovery",
@@ -588,5 +589,23 @@ def forgot_pwd():
             assert outbox[0].body == "This is a test."
 
 
-        # TODO - add confirmation that email has been sent
         return render_template("confirmation.html")
+
+@app.route('/reset_password/<index>', methods=['GET', 'POST'])
+def reset_password(index):
+    if request.method == 'GET':
+        return render_template("reset.html", index=index)
+    else:
+        new_password = generate_password_hash(request.form.get("new_password"))
+        confirm_new_password = request.form.get("confirm_new_password")
+
+        # TODO - show user that passwords do not match
+        if not check_password_hash(new_password, confirm_new_password):
+            return redirect(url_for('reset_password', index=index))
+
+        # connect to database
+        conn = sqlite3.connect('database/database.db')
+        db = conn.cursor()
+        
+        return redirect('/login')
+

--- a/app/templates/confirmation.html
+++ b/app/templates/confirmation.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %} {% block head %}
+<title>Password Recovery</title>
+<link rel="stylesheet" href="static/styles/register.css">
+{% endblock %}
+
+{% block app_content %}
+<div class="col-md-5 main-section">
+    <div class="modal-content">
+        <div>
+            <b>A recovery email has been sent to the indicated account. If it hasn't shown up in the next few minutes, try again.</b>
+        </div>
+        <div class="border-top pt-3">
+            <small class="text-muted">
+                <a class="ml-2" href="{{ url_for('login') }}">Login</a>
+            </small>
+        </div>
+        <br>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/forgot_pwd.html
+++ b/app/templates/forgot_pwd.html
@@ -7,7 +7,7 @@
 <div class="col-md-5 main-section">
     <div class="modal-content">
         <div>
-            <form action="/login" method="POST">
+            <form action="/forgot_pwd" method="POST">
                 <fieldset class="form-group">
                     <legend class="border-bottom mb-4">
                         <p class="loginTitle">Forgot Password</p>
@@ -23,7 +23,7 @@
 
                 </fieldset>
                 <div class="form-group" style="margin-top: 20px;">
-                    <input type="submit" value="Continue" class="btn float-right btn-md btn-outline-primary">
+                    <input type="submit" name="recovery" value="Continue" class="btn float-right btn-md btn-outline-primary">
                 </div>
                 <br> <br>
             </form>

--- a/app/templates/forgot_pwd.html
+++ b/app/templates/forgot_pwd.html
@@ -30,7 +30,7 @@
         </div>
         <div class="border-top pt-3">
             <small class="text-muted">
-                Go back instead? <a class="ml-2" href="{{ url_for('login') }}">Login</a>
+                Go back: <a class="ml-2" href="{{ url_for('login') }}">Login</a>
             </small>
         </div>
         <br>

--- a/app/templates/reset.html
+++ b/app/templates/reset.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %} {% block head %}
+<title>Password Recovery</title>
+<link rel="stylesheet" href="static/styles/register.css">
+{% endblock %}
+
+{% block app_content %}
+<div class="col-md-5 main-section">
+    <div class="modal-content" style="margin: auto;">
+        <div>
+            <form action="{{ url_for('reset_password', index=index) }}" method="POST">
+                <fieldset class="form-group">
+                    <legend class="border-bottom mb-4">
+                        <p class="loginTitle">Reset Password</p>
+                    </legend>
+
+                    <div class="form-group">
+                        <label class="form-control-label">Enter New Password:</label>
+                        <input type="text" autofocus="on" class="form-control" name="new_password" required>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-control-label">Confirm New Password:</label>
+                        <input type="text" autofocus="on" class="form-control" name="confirm_new_password" required>
+                    </div>
+
+                </fieldset>
+                <div class="form-group" style="margin-top: 20px;">
+                    <input type="submit" name="recovery" value="Continue" class="btn float-right btn-md btn-outline-primary">
+                </div>
+                <br> <br>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ dominate==2.5.1
 Flask==1.1.2
 Flask-Bootstrap==3.3.7.1
 Flask-Login==0.5.0
+Flask-Mail
 Flask-Migrate==2.5.3
 Flask-SQLAlchemy==2.4.4
 Flask-Session


### PR DESCRIPTION
# Description
This branch builds ~90% of the reset password feature. The usage is as follows:
- Click "Forgot your password?" on login page (**implemented**)
- User is redirected to a page where they enter a recovery email (screenshot below) (**implemented**)
- Upon entering email, the `Flask Mail` library sends an email with a recovery link to the target user's email (AKA their username) (**not implemented**)
- User follows link to a new dynamic page on the site where they are prompted to enter and confirm the new password (screenshot below) (**implemented**)
- Database info is updated with the new, hashed password and user is redirected to login page (**implemented**)

## Issues
As per the above, the actual email with a reset link isn't sent. This is for a few reasons:
- Running unit tests that involve emails can become very messy. I updated the `app.config["TESTING"]` to be `True` which will automatically suppress all email sending for now since we don't have dedicated user emails to check. This shouldn't impact whether or not the feature works, just the actual last step of sending the email. I've written the boilerplate for sending the email, we just need to insert the sender info and the recovery url into the body.
- I couldn't figure out how to create the dynamic url for accessing the recovery page. I can access it manually by typing it into my browser as `localhost:5000/reset_password/blahblahblah` but I didn't know how one would access this page from an email since this is all running locally. I made a note in the misc backend fixes card on our GitKraken to come back to this near the end of development. If you have any ideas on how to do this now though, please let me know!
- I couldn't figure out how to get the reset password page to look centered on desktop. Looks fine on mobile though (both included below). We'll have to take a look at this when we check the responsive of the webpage @ayushiatsharma @anizhou 

## Screenshots (if needed) 
![forgot](https://user-images.githubusercontent.com/59075610/103036199-cf14ef80-452e-11eb-9eec-156fae67599f.png)
![reset_desktop](https://user-images.githubusercontent.com/59075610/103036206-d2a87680-452e-11eb-81b0-ca76401e5b78.png)
![reset_mobile](https://user-images.githubusercontent.com/59075610/103036208-d50ad080-452e-11eb-9c3b-5d9d62e707d0.png)

